### PR TITLE
Add alias to BreadcrumbBuilder

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -12,6 +12,10 @@ services:
         arguments:
             - '@slope_it.breadcrumb.item_factory'
 
+    SlopeIt\BreadcrumbBundle\Service\BreadcrumbBuilder:
+        alias: slope_it.breadcrumb.builder
+        public: true
+
     slope_it.breadcrumb.item_factory:
         class: SlopeIt\BreadcrumbBundle\Service\BreadcrumbItemFactory
 


### PR DESCRIPTION
Add alias to BreadcrumbBuilder.
This allow to autowire the service like this:

```php
<?php

...

use SlopeIt\BreadcrumbBundle\Service\BreadcrumbBuilder;

class AdminStayController extends AbstractController
{
    public function index(BreadcrumbBuilder $breadcrumb)
    {
        ...
    }
}
```

Closes #10 