### PR TITLE
Add option to disable parameter extraction from current route

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,8 +15,10 @@ class Configuration implements ConfigurationInterface
         $builder = new TreeBuilder('slope_it_breadcrumb');
         $builder->getRootNode()
             ->children()
+                ->booleanNode('extract_current_route_parameters')->defaultTrue()->end()
                 ->scalarNode('template')->defaultValue('@SlopeItBreadcrumb/breadcrumb.html.twig')->end()
             ->end();
+
         return $builder;
     }
 }

--- a/src/DependencyInjection/SlopeItBreadcrumbExtension.php
+++ b/src/DependencyInjection/SlopeItBreadcrumbExtension.php
@@ -27,6 +27,7 @@ class SlopeItBreadcrumbExtension extends Extension
 
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
+        $container->setParameter('slope_it_breadcrumb.extract_parameters', $config['extract_current_route_parameters']);
         $container->setParameter('slope_it_breadcrumb.template', $config['template']);
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -22,6 +22,7 @@ services:
             - '@translator'
             - '@router'
             - '@request_stack'
+            - '%slope_it_breadcrumb.extract_parameters%'
 
     slope_it.breadcrumb.twig_extension:
         class: SlopeIt\BreadcrumbBundle\Twig\BreadcrumbExtension

--- a/src/Service/BreadcrumbItemProcessor.php
+++ b/src/Service/BreadcrumbItemProcessor.php
@@ -35,16 +35,23 @@ class BreadcrumbItemProcessor
      */
     private $translator;
 
+    /**
+     * @var bool
+     */
+    private $extractParameters;
+
     public function __construct(
         PropertyAccessorInterface $propertyAccessor,
         TranslatorInterface $translator,
         RouterInterface $router,
-        RequestStack $requestStack
+        RequestStack $requestStack,
+        bool $extractParameters
     ) {
         $this->propertyAccessor = $propertyAccessor;
         $this->translator = $translator;
         $this->router = $router;
         $this->requestStack = $requestStack;
+        $this->extractParameters = $extractParameters;
     }
 
     /**
@@ -64,9 +71,11 @@ class BreadcrumbItemProcessor
         // Process the route
         // TODO: cache parameters extracted from current request
         $params = [];
-        foreach ($this->requestStack->getCurrentRequest()->attributes as $key => $value) {
-            if ($key[0] !== '_') {
-                $params[$key] = $value;
+        if ($this->extractParameters) {
+            foreach ($this->requestStack->getCurrentRequest()->attributes as $key => $value) {
+                if ($key[0] !== '_') {
+                    $params[$key] = $value;
+                }
             }
         }
         foreach ($item->getRouteParams() ?: [] as $key => $value) {

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -2,9 +2,9 @@
 
 namespace SlopeIt\Tests\BreadcrumbBundle\DependencyInjection;
 
-use SlopeIt\BreadcrumbBundle\DependencyInjection\Configuration;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
+use SlopeIt\BreadcrumbBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
 
 /**
@@ -19,17 +19,20 @@ class ConfigurationTest extends TestCase
      *
      * @covers ::getConfigTreeBuilder
      */
-    public function test_load_overrideTemplate()
+    public function testLoadOverrideTemplate()
     {
         $config = [
             'slope_it_breadcrumb' => [
-                'template' => 'aTemplate.html.twig'
-            ]
+                'template' => 'aTemplate.html.twig',
+            ],
         ];
 
         $processor = new Processor();
         $processedConfig = $processor->processConfiguration(new Configuration(), $config);
 
-        $this->assertEquals(['template' => 'aTemplate.html.twig'], $processedConfig);
+        $this->assertEquals([
+            'template' => 'aTemplate.html.twig',
+            'extract_current_route_parameters' => true,
+        ], $processedConfig);
     }
 }

--- a/tests/Service/BreadcrumbItemProcessorTest.php
+++ b/tests/Service/BreadcrumbItemProcessorTest.php
@@ -59,7 +59,8 @@ class BreadcrumbItemProcessorTest extends TestCase
             $this->propertyAccessor,
             $this->translator,
             $this->router,
-            $this->requestStack
+            $this->requestStack,
+            true
         );
     }
 


### PR DESCRIPTION
Add an option to disable parameter extraction from current route:

```yaml
slope_it_breadcrumb:
  extract_current_route_parameters: false
```

It defaults to `true` so no backward compatibility break.

Closes #8 