### PR TITLE
Fix non string route param exception

### DIFF
--- a/src/Service/BreadcrumbItemProcessor.php
+++ b/src/Service/BreadcrumbItemProcessor.php
@@ -70,7 +70,7 @@ class BreadcrumbItemProcessor
             }
         }
         foreach ($item->getRouteParams() ?: [] as $key => $value) {
-            if ($value[0] === '$') {
+            if (is_string($value) && $value[0] === '$') {
                 $params[$key] = $this->parseValue($value, $variables);
             } else {
                 $params[$key] = $value;


### PR DESCRIPTION
Check if the value is a string before trying to read its first letter.

Closes #9 