### PR TITLE
Allow parsing multiple parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ In which the first two items are anchors and the last one is text only.
 Under the hood, this is the business logic involved, for each item, in the breadcrumb generation:
 * `label` will be the printed text. It can be either:
   * A "static" string (the translator will attempt to translate it by using it as a translation key)
-  * A special string, prepended with `$`. In this case, the breadcrumb label will be extracted from the variable passed to the template. Property paths can be used, e.g.: `$variable.property.path`
+  * A special string, prepended with `$`. In this case, the breadcrumb label will be extracted from the variable passed to the template. Property paths can be used, e.g.: `$variable.property.path`.
+  * You can even build a complex label by mixing static string and multiple variables: `Gallery "$gallery.title" - $gallery.year`.
 * `route` will be used to generate the url for the item anchor (if provided). If not provided, the item will not be clickable.
 * `params` will be used to generate the url related to the provided route. It's an associative array where each value can be either:
   * A "static" string

--- a/src/Service/BreadcrumbItemProcessor.php
+++ b/src/Service/BreadcrumbItemProcessor.php
@@ -53,7 +53,7 @@ class BreadcrumbItemProcessor
     public function process(BreadcrumbItem $item, array $variables): ProcessedBreadcrumbItem
     {
         // Process the label
-        if ($item->getLabel() && $item->getLabel()[0] === '$') {
+        if ($item->getLabel() && $this->isValueParsable($item->getLabel())) {
             $processedLabel = $this->parseValue($item->getLabel(), $variables);
         } elseif (!$item->getLabel() || $item->getTranslationDomain() === false) {
             $processedLabel = $item->getLabel();
@@ -70,7 +70,7 @@ class BreadcrumbItemProcessor
             }
         }
         foreach ($item->getRouteParams() ?: [] as $key => $value) {
-            if ($value[0] === '$') {
+            if ($this->isValueParsable($value)) {
                 $params[$key] = $this->parseValue($value, $variables);
             } else {
                 $params[$key] = $value;
@@ -86,6 +86,23 @@ class BreadcrumbItemProcessor
         return new ProcessedBreadcrumbItem($processedLabel, $processedUrl);
     }
 
+    // Regex used to match parsable values (based on: https://www.php.net/manual/en/functions.user-defined.php)
+    private const PARSABLE_VALUE_REGEX = '/\$[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*(\.[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)*/';
+
+    /**
+     * Check if the given variable is a parsable string
+     *
+     * @param mixed $expression
+     */
+    private function isValueParsable($expression): bool
+    {
+        if (!is_string($expression)) {
+            return false;
+        }
+
+        return preg_match_all(self::PARSABLE_VALUE_REGEX, $expression) > 0;
+    }
+
     /**
      * Returns the value contained in the variable name (with optional property path) of the given expression.
      *
@@ -93,21 +110,23 @@ class BreadcrumbItemProcessor
      */
     private function parseValue(string $expression, array $variables)
     {
-        $components = explode('.', $expression, 2);
-        $variableName = substr($components[0], 1); // Remove the $ prefix;
-        $propertyPath = $components[1] ?? null;
+        return preg_replace_callback(self::PARSABLE_VALUE_REGEX, function($matches) use ($variables) {
+            $components = explode('.', $matches[0], 2);
+            $variableName = substr($components[0], 1); // Remove the $ prefix;
+            $propertyPath = $components[1] ?? null;
 
-        if (!array_key_exists($variableName, $variables)) {
-            throw new \RuntimeException('The variables array passed to process the breadcrumb item does not have'
-                . ' variable "' . $variableName . '". Make sure you are passing that variable to the template in which'
-                . ' this breadcrumb is rendered.');
-        }
+            if (!array_key_exists($variableName, $variables)) {
+                throw new \RuntimeException('The variables array passed to process the breadcrumb item does not have'
+                    . ' variable "' . $variableName . '". Make sure you are passing that variable to the template in which'
+                    . ' this breadcrumb is rendered.');
+            }
 
-        if (!$propertyPath) {
-            // If this is a "top level" variable, return its value directly.
-            return $variables[$variableName];
-        }
+            if (!$propertyPath) {
+                // If this is a "top level" variable, return its value directly.
+                return $variables[$variableName];
+            }
 
-        return $this->propertyAccessor->getValue($variables[$variableName], $propertyPath);
+            return $this->propertyAccessor->getValue($variables[$variableName], $propertyPath);
+        }, $expression);
     }
 }

--- a/tests/Service/BreadcrumbItemProcessorTest.php
+++ b/tests/Service/BreadcrumbItemProcessorTest.php
@@ -95,6 +95,23 @@ class BreadcrumbItemProcessorTest extends TestCase
     /**
      * @covers ::process
      */
+    public function test_process_item_with_label_as_multiple_variables_with_property_path()
+    {
+        $item = new BreadcrumbItem('$variableName.property.nestedProperty - "$variableName.property.nestedProperty"');
+
+        $object = (object) ['property' => (object) ['nestedProperty' => 'propertyValue']];
+
+        $this->propertyAccessor->expects('getValue')->with($object, 'property.nestedProperty')
+            ->andReturn('propertyValue');
+
+        $processedItem = $this->SUT->process($item, ['variableName' => $object]);
+
+        $this->assertSame('propertyValue - "propertyValue"', $processedItem->getTranslatedLabel());
+    }
+
+    /**
+     * @covers ::process
+     */
     public function test_process_item_with_label_not_to_be_translated()
     {
         $item = new BreadcrumbItem('Already translated label', null, null, false);


### PR DESCRIPTION
Allow parsing multiple parameters and adding static string in labels:

```php
#[Breadcrumb(['label' => 'Galerie $gallery.title - $gallery.year'])]
```
Will render something like:
```
Galerie vacance - 2021
```

Shouldn't do any BC break.

Closes #7, #9