### PR TITLE
Issue #8: Improve route generation by using UrlGenerator's request context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea
 /vendor
+/var
 phpunit.xml
 composer.lock
 .phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ class AppKernel extends Kernel
 {
     public function registerBundles()
     {
-        $bundles = array(
+        $bundles = [
             // ...
             new SlopeIt\BreadcrumbBundle\SlopeItBreadcrumbBundle(),
-        );
+        ];
         // ...
     }
     // ...
@@ -209,7 +209,3 @@ However, in your template you'll just have to iterate over the `items` variable 
 * Do you think documentation can be improved?
 
 Under any of these circumstances, please fork this repo and create a pull request. We are more than happy to accept contributions!
-
-## Maintainer
-
-[@andreasprega](https://twitter.com/andreasprega)

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,15 @@
         "doctrine/annotations": "^1.0",
         "symfony/framework-bundle": "^4.0|^5.0",
         "symfony/property-access": "^4.0|^5.0",
-        "symfony/translation-contracts": "^1.0|^2.0",
+        "symfony/translation": "^4.0|^5.0",
         "symfony/yaml": "^4.0|^5.0",
         "twig/twig": "^2.10|^3.0"
     },
     "require-dev": {
-        "mockery/mockery": "1.4.3",
-        "phpunit/phpunit": "8.5.15"
+        "mockery/mockery": "^1.3",
+        "phpunit/phpunit": "8.5.15",
+        "symfony/dependency-injection": "^4.0|^5.0",
+        "symfony/monolog-bundle": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/src/Service/BreadcrumbItemProcessor.php
+++ b/src/Service/BreadcrumbItemProcessor.php
@@ -6,7 +6,7 @@ use SlopeIt\BreadcrumbBundle\Model\BreadcrumbItem;
 use SlopeIt\BreadcrumbBundle\Model\ProcessedBreadcrumbItem;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -26,9 +26,9 @@ class BreadcrumbItemProcessor
     private $requestStack;
 
     /**
-     * @var RouterInterface
+     * @var UrlGeneratorInterface
      */
-    private $router;
+    private $urlGenerator;
 
     /**
      * @var TranslatorInterface
@@ -38,19 +38,55 @@ class BreadcrumbItemProcessor
     public function __construct(
         PropertyAccessorInterface $propertyAccessor,
         TranslatorInterface $translator,
-        RouterInterface $router,
+        UrlGeneratorInterface $urlGenerator,
         RequestStack $requestStack
     ) {
         $this->propertyAccessor = $propertyAccessor;
         $this->translator = $translator;
-        $this->router = $router;
+        $this->urlGenerator = $urlGenerator;
         $this->requestStack = $requestStack;
+    }
+
+    /**
+     * @param BreadcrumbItem[] $items
+     * @param array<string, mixed> $variables
+     * @return ProcessedBreadcrumbItem[]
+     */
+    public function process(array $items, array $variables): array
+    {
+        $requestContext = $this->urlGenerator->getContext();
+
+        // Save original parameters of the request context, so they can be re-applied after url generation is done.
+        $originalRequestContextParameters = $requestContext->getParameters();
+
+        // Use the request context to pre-set parameters that are already present as attributes of the current request.
+        // This allows for URL generation using parameters already present in the request path without having to
+        // re-specify them all the time. These parameters won't be added unnecessarily if they are not needed for the
+        // route being generated.
+        foreach ($this->requestStack->getCurrentRequest()->attributes as $key => $value) {
+            if ($key[0] !== '_') {
+                $requestContext->setParameter($key, $value);
+            }
+        }
+
+        // Process items with our own "modified" request context
+        $processedItems = array_map(
+            function (BreadcrumbItem $item) use ($variables) {
+                return $this->processItem($item, $variables);
+            },
+            $items
+        );
+
+        // Restore parameters originally present in the context so that this method doesn't have any side effects.
+        $this->urlGenerator->getContext()->setParameters($originalRequestContextParameters);
+
+        return $processedItems;
     }
 
     /**
      * @param array<string, mixed> $variables
      */
-    public function process(BreadcrumbItem $item, array $variables): ProcessedBreadcrumbItem
+    private function processItem(BreadcrumbItem $item, array $variables): ProcessedBreadcrumbItem
     {
         // Process the label
         if ($item->getLabel() && $item->getLabel()[0] === '$') {
@@ -62,23 +98,17 @@ class BreadcrumbItemProcessor
         }
 
         // Process the route
-        // TODO: cache parameters extracted from current request
-        $params = [];
-        foreach ($this->requestStack->getCurrentRequest()->attributes as $key => $value) {
-            if ($key[0] !== '_') {
-                $params[$key] = $value;
-            }
-        }
-        foreach ($item->getRouteParams() ?: [] as $key => $value) {
-            if (is_string($value) && $value[0] === '$') {
-                $params[$key] = $this->parseValue($value, $variables);
-            } else {
-                $params[$key] = $value;
-            }
-        }
-
         if ($item->getRoute() !== null) {
-            $processedUrl = $this->router->generate($item->getRoute(), $params);
+            $params = [];
+            foreach ($item->getRouteParams() ?: [] as $key => $value) {
+                if (is_string($value) && $value[0] === '$') {
+                    $params[$key] = $this->parseValue($value, $variables);
+                } else {
+                    $params[$key] = $value;
+                }
+            }
+
+            $processedUrl = $this->urlGenerator->generate($item->getRoute(), $params);
         } else {
             $processedUrl = null;
         }

--- a/src/Twig/BreadcrumbExtension.php
+++ b/src/Twig/BreadcrumbExtension.php
@@ -67,11 +67,11 @@ class BreadcrumbExtension extends AbstractExtension
 
     public function renderBreadcrumb(Environment $twig, array $context): string
     {
-        $breadcrumb = [];
-        foreach ($this->builder->getItems() as $item) {
-            $breadcrumb[] = $this->itemProcessor->process($item, $context);
-        }
-
-        return $twig->render($this->template, [ 'items' => $breadcrumb ]);
+        return $twig->render(
+            $this->template,
+            [
+                'items' => $this->itemProcessor->process($this->builder->getItems(), $context)
+            ]
+        );
     }
 }

--- a/tests/Fixtures/TestKernel.php
+++ b/tests/Fixtures/TestKernel.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace SlopeIt\Tests\BreadcrumbBundle\Fixtures;
+
+use SlopeIt\BreadcrumbBundle\SlopeItBreadcrumbBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\MonologBundle\MonologBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+
+class TestKernel extends Kernel
+{
+    public function registerBundles(): iterable
+    {
+        return [
+            new MonologBundle(),
+            new FrameworkBundle(),
+            new SlopeItBreadcrumbBundle(),
+        ];
+    }
+
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new class() implements CompilerPassInterface {
+            public function process(ContainerBuilder $container): void
+            {
+                foreach ($container->getDefinitions() as $definition) {
+                    $definition->setPublic(true);
+                }
+            }
+        });
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__.'/config/config.yml');
+    }
+}

--- a/tests/Fixtures/config/config.yml
+++ b/tests/Fixtures/config/config.yml
@@ -1,0 +1,11 @@
+framework:
+    secret: 'NOT-SO-SECRET'
+    test: true
+    router:
+        resource: "%kernel.project_dir%/tests/Fixtures/config/routing.yml"
+    translator:
+        logging: true
+    cache: true
+    annotations:
+        enabled: true
+        cache: file

--- a/tests/Fixtures/config/routing.yml
+++ b/tests/Fixtures/config/routing.yml
@@ -1,0 +1,5 @@
+parent_route:
+    path: /parent-path/{component1}/{component2}
+
+child_route:
+    path: /parent-path/{component1}/child-path/{component3}

--- a/tests/Integration/Service/BreadcrumbItemProcessorTest.php
+++ b/tests/Integration/Service/BreadcrumbItemProcessorTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace SlopeIt\Tests\BreadcrumbBundle\Integration\Service;
+
+use SlopeIt\BreadcrumbBundle\Model\BreadcrumbItem;
+use SlopeIt\BreadcrumbBundle\Service\BreadcrumbItemProcessor;
+use SlopeIt\Tests\BreadcrumbBundle\Fixtures\TestKernel;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class BreadcrumbItemProcessorTest extends KernelTestCase
+{
+    protected static function getKernelClass()
+    {
+        return TestKernel::class;
+    }
+
+    public function test_process_item_with_reused_path_parameters()
+    {
+        // Preconditions
+        // NOTE: see `tests/Fixtures/config/routing.yml`
+        $request = Request::create('http://localhost/parent-path/foo/bar');
+
+        // This is done by the HttpKernel when a request is sent
+        $requestStack = self::getContainer()->get(RequestStack::class);
+        $requestStack->push($request);
+
+        // This framework listener is responsible for setting path parameters as request attributes
+        $listener = self::getContainer()->get('router_listener');
+        $listener->onKernelRequest(new RequestEvent(self::$kernel, $request, HttpKernelInterface::MAIN_REQUEST));
+
+        // Action
+        /** @var BreadcrumbItemProcessor $SUT */
+        $SUT = self::getContainer()->get('slope_it.breadcrumb.item_processor');
+        $processedBreadcrumbItems = $SUT->process(
+            [
+                new BreadcrumbItem('Parent page', 'parent_route'),
+                new BreadcrumbItem('Child page', 'child_route', ['component3' => 'baz']),
+            ],
+            []
+        );
+
+        // Verification: url of parent route was reconstructed as is, without needing to specify "component1" and
+        // "component2" because already present.
+        $this->assertSame('/parent-path/foo/bar', $processedBreadcrumbItems[0]->getUrl());
+
+        // Verification: url of child route was constructed by implicitly reusing "component1" from current, parent path
+        // "component3" was explicitly provided in the breadcrum item.
+        // "component2" was ignored as not present in child path.
+        $this->assertSame('/parent-path/foo/child-path/baz', $processedBreadcrumbItems[1]->getUrl());
+    }
+}

--- a/tests/Unit/Annotation/BreadcrumbTest.php
+++ b/tests/Unit/Annotation/BreadcrumbTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SlopeIt\Tests\BreadcrumbBundle\Annotation;
+namespace SlopeIt\Tests\BreadcrumbBundle\Unit\Annotation;
 
-use SlopeIt\BreadcrumbBundle\Annotation\Breadcrumb;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
+use SlopeIt\BreadcrumbBundle\Annotation\Breadcrumb;
 
 /**
  * @coversDefaultClass \SlopeIt\BreadcrumbBundle\Annotation\Breadcrumb

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SlopeIt\Tests\BreadcrumbBundle\DependencyInjection;
+namespace SlopeIt\Tests\BreadcrumbBundle\Unit\DependencyInjection;
 
-use SlopeIt\BreadcrumbBundle\DependencyInjection\Configuration;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
+use SlopeIt\BreadcrumbBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
 
 /**

--- a/tests/Unit/DependencyInjection/SlopeItBreadcrumbExtensionTest.php
+++ b/tests/Unit/DependencyInjection/SlopeItBreadcrumbExtensionTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace SlopeIt\Tests\BreadcrumbBundle\DependencyInjection;
+namespace SlopeIt\Tests\BreadcrumbBundle\Unit\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use SlopeIt\BreadcrumbBundle\DependencyInjection\SlopeItBreadcrumbExtension;

--- a/tests/Unit/EventListener/BreadcrumbListenerTest.php
+++ b/tests/Unit/EventListener/BreadcrumbListenerTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace SlopeIt\Tests\BreadcrumbBundle\EventListener;
+namespace SlopeIt\Tests\BreadcrumbBundle\Unit\EventListener;
 
-use SlopeIt\BreadcrumbBundle\EventListener\BreadcrumbListener;
-use SlopeIt\BreadcrumbBundle\Service\BreadcrumbBuilder;
 use Doctrine\Common\Annotations\Reader;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
+use SlopeIt\BreadcrumbBundle\EventListener\BreadcrumbListener;
+use SlopeIt\BreadcrumbBundle\Service\BreadcrumbBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;

--- a/tests/Unit/Model/BreadcrumbItemTest.php
+++ b/tests/Unit/Model/BreadcrumbItemTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SlopeIt\Tests\BreadcrumbBundle\Model;
+namespace SlopeIt\Tests\BreadcrumbBundle\Unit\Model;
 
-use SlopeIt\BreadcrumbBundle\Model\BreadcrumbItem;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
+use SlopeIt\BreadcrumbBundle\Model\BreadcrumbItem;
 
 /**
  * @coversDefaultClass \SlopeIt\BreadcrumbBundle\Model\BreadcrumbItem

--- a/tests/Unit/Model/ProcessedBreadcrumbItemTest.php
+++ b/tests/Unit/Model/ProcessedBreadcrumbItemTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SlopeIt\Tests\BreadcrumbBundle\Model;
+namespace SlopeIt\Tests\BreadcrumbBundle\Unit\Model;
 
-use SlopeIt\BreadcrumbBundle\Model\ProcessedBreadcrumbItem;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
+use SlopeIt\BreadcrumbBundle\Model\ProcessedBreadcrumbItem;
 
 /**
  * @coversDefaultClass \SlopeIt\BreadcrumbBundle\Model\ProcessedBreadcrumbItem

--- a/tests/Unit/Service/BreadcrumbBuilderTest.php
+++ b/tests/Unit/Service/BreadcrumbBuilderTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace SlopeIt\Tests\BreadcrumbBundle\Service;
+namespace SlopeIt\Tests\BreadcrumbBundle\Unit\Service;
 
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 use SlopeIt\BreadcrumbBundle\Model\BreadcrumbItem;
 use SlopeIt\BreadcrumbBundle\Service\BreadcrumbBuilder;
 use SlopeIt\BreadcrumbBundle\Service\BreadcrumbItemFactory;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \SlopeIt\BreadcrumbBundle\Service\BreadcrumbBuilder

--- a/tests/Unit/Service/BreadcrumbItemFactoryTest.php
+++ b/tests/Unit/Service/BreadcrumbItemFactoryTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SlopeIt\Tests\BreadcrumbBundle\Service;
+namespace SlopeIt\Tests\BreadcrumbBundle\Unit\Service;
 
-use SlopeIt\BreadcrumbBundle\Model\BreadcrumbItem;
-use SlopeIt\BreadcrumbBundle\Service\BreadcrumbItemFactory;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
+use SlopeIt\BreadcrumbBundle\Model\BreadcrumbItem;
+use SlopeIt\BreadcrumbBundle\Service\BreadcrumbItemFactory;
 
 /**
  * @coversDefaultClass \SlopeIt\BreadcrumbBundle\Service\BreadcrumbItemFactory


### PR DESCRIPTION
This allows to only re-use route path attributes when they are needed by the route being generated.
Previous method, instead, always set them as explicit parameters -- this caused extra query string
parameters whenever a path attribute of the "parent" route wasn't present in the route being generated.