### PR TITLE
feat: add support for Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     "require": {
         "php": ">=7.3.0",
         "doctrine/annotations": "^1.0",
-        "symfony/framework-bundle": "^4.0|^5.0",
-        "symfony/property-access": "^4.0|^5.0",
-        "symfony/translation": "^4.0|^5.0",
-        "symfony/yaml": "^4.0|^5.0",
+        "symfony/framework-bundle": "^4.0|^5.0|^6.0",
+        "symfony/property-access": "^4.0|^5.0|^6.0",
+        "symfony/translation": "^4.0|^5.0|^6.0",
+        "symfony/yaml": "^4.0|^5.0|^6.0",
         "twig/twig": "^2.10|^3.0"
     },
     "require-dev": {

--- a/tests/Integration/Service/BreadcrumbItemProcessorTest.php
+++ b/tests/Integration/Service/BreadcrumbItemProcessorTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class BreadcrumbItemProcessorTest extends KernelTestCase
 {
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
         return TestKernel::class;
     }


### PR DESCRIPTION
I just added the support in `composer.json`.
The test suit run fine locally, without any depreciation warning.

Also, add the return type was needed because of this error:

```
PHP Fatal error:  Declaration of SlopeIt\Tests\BreadcrumbBundle\Integration\Service\BreadcrumbItemProcessorTest::getKernelClass() must be compatible with Symfony\Bundle\FrameworkBundle\Test\KernelTestCase::getKernelClass(): string in /home/jupiter007/Projects/Web/breadcrumb-bundle/tests/Integration/Service/BreadcrumbItemProcessorTest.php on line 17
```