### PR TITLE
Support TranslatableMessage as a label value

### DIFF
--- a/src/Service/BreadcrumbItemProcessor.php
+++ b/src/Service/BreadcrumbItemProcessor.php
@@ -7,6 +7,7 @@ use SlopeIt\BreadcrumbBundle\Model\ProcessedBreadcrumbItem;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -78,7 +79,12 @@ class BreadcrumbItemProcessor
     {
         // Process the label
         if ($item->label && \str_starts_with($item->label, '$')) {
-            $processedLabel = $this->parseValue($item->label, $variables);
+            $labelValue = $this->parseValue($item->label, $variables);
+            if ($labelValue instanceof TranslatableMessage) {
+                $processedLabel = $labelValue->trans($this->translator, $item->translationDomain ?: null);
+            } else {
+                $processedLabel = $labelValue;
+            }
         } elseif (!$item->label || $item->translationDomain === false) {
             $processedLabel = $item->label;
         } else {


### PR DESCRIPTION
Currently, labels can only be a static string, a translated string without parameters, or a value retrieved from a property path. It would be nice to have a system for translated strings _with_ parameters. My use case is that for some breadcrumb I would like to prepend something to a property, and/or surround a property with quotes (e.g. instead of rendering the dynamic value `prop` as `prop`, I would like `Property : “prop”`).

This PR implements this use case by allowing the property path given as label to resolve to a TranslatableMessage instead of a plain string. It respects the `translationDomain` setting except that false is not considered differently than null so that the default domain is used (indeed it would make no sense to disable translation on a TranslatableMessage).

This allows setting up a breadcrumb like so:

```php
// The breadcrumb uses the breadcrumbLabel property of a Tier object.
const array TIER_BREADCRUMB = [
    'label' => '$tier.breadcrumbLabel',
    'route' => 'app_tier_detail',
    'params' => ['id' => '$tier.id'],
    'translationDomain' => null,
];

// The breadcrumbLabel property returns a TranslatableMessage instead of a plain string.
class Tier {
  public function getBreadcrumbLabel(): TranslatableMessage {
    return new TranslatableMessage('trans_str_with_params', ['%param%' => $this->anotherProperty]);
  }
}

// The Route is not relevant here.
#[Route('/tiers/{id}', name: 'app_tier_detail')]
#[Breadcrumb(TIER_BREADCRUMB)]
public function myRoute(int $id) { /* … */ }
```

Let me know what you think!