### PR TITLE
Support TranslatableMessage as a label value

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Furthermore, in case you need to know whether the breadcrumb has items or not, y
 Under the hood, this is the business logic involved, for each item, in the breadcrumb generation:
 * `label` will be the printed text. It can be either:
   * A "static" string (the translator will attempt to translate it by using it as a translation key)
-  * A special string, prepended with `$`. In this case, the breadcrumb label will be extracted from the variable passed to the template. Property paths can be used, e.g.: `$variable.property.path`
+  * A special string, prepended with `$`. In this case, the breadcrumb label will be extracted from the variable passed to the template. Property paths can be used, e.g.: `$variable.property.path`. The variable can resolve to a TranslatableMessage instead of a string; in that case, the translated string will be used.
 * `route` will be used to generate the url for the item anchor (if provided). If not provided, the item will not be clickable.
 * `params` will be used to generate the url related to the provided route. It's an associative array where each value can be either:
   * A "static" string

--- a/src/Service/BreadcrumbItemProcessor.php
+++ b/src/Service/BreadcrumbItemProcessor.php
@@ -7,6 +7,7 @@ use SlopeIt\BreadcrumbBundle\Model\ProcessedBreadcrumbItem;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -78,7 +79,12 @@ class BreadcrumbItemProcessor
     {
         // Process the label
         if ($item->label && \str_starts_with($item->label, '$')) {
-            $processedLabel = $this->parseValue($item->label, $variables);
+            $labelValue = $this->parseValue($item->label, $variables);
+            if ($labelValue instanceof TranslatableMessage) {
+                $processedLabel = $labelValue->trans($this->translator);
+            } else {
+                $processedLabel = $labelValue;
+            }
         } elseif (!$item->label || $item->translationDomain === false) {
             $processedLabel = $item->label;
         } else {

--- a/tests/Unit/Service/BreadcrumbItemProcessorTest.php
+++ b/tests/Unit/Service/BreadcrumbItemProcessorTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[CoversClass(BreadcrumbItemProcessor::class)]
@@ -107,6 +108,40 @@ class BreadcrumbItemProcessorTest extends TestCase
             ->andReturn('Translated label');
 
         $processedItems = $this->SUT->process([$item], []);
+
+        $this->assertSame('Translated label', $processedItems[0]->translatedLabel);
+    }
+
+    public function test_process_item_with_label_as_translatable_message_with_default_transition_domain()
+    {
+        $item = new BreadcrumbItem('$variableName.property');
+
+        $translatable = new TranslatableMessage('translatable_key');
+        $object = (object) ['getProperty' => fn () => $translatable];
+
+        $this->propertyAccessor->expects('getValue')->with($object, 'property')
+            ->andReturn($translatable);
+        $this->translator->expects('trans')->with('translatable_key', [], null, null)
+            ->andReturn('Translated label');
+
+        $processedItems = $this->SUT->process([$item], ['variableName' => $object]);
+
+        $this->assertSame('Translated label', $processedItems[0]->translatedLabel);
+    }
+
+    public function test_process_item_with_label_as_translatable_message_with_custom_transition_domain()
+    {
+        $item = new BreadcrumbItem('$variableName.property', translationDomain: 'custom_domain');
+
+        $translatable = new TranslatableMessage('translatable_key', domain: 'custom_domain');
+        $object = (object) ['getProperty' => fn () => $translatable];
+
+        $this->propertyAccessor->expects('getValue')->with($object, 'property')
+            ->andReturn($translatable);
+        $this->translator->expects('trans')->with('translatable_key', [], 'custom_domain', null)
+            ->andReturn('Translated label');
+
+        $processedItems = $this->SUT->process([$item], ['variableName' => $object]);
 
         $this->assertSame('Translated label', $processedItems[0]->translatedLabel);
     }


### PR DESCRIPTION
This is a reopening of [PR 29](https://github.com/slope-it/breadcrumb-bundle/pull/29). 

I added two unit tests and a line in the readme to tell about the feature. I'm not used to testing in PHP yet so let me know if there is something I can improve.

Copying the original message below.

---

Currently, labels can only be a static string, a translated string without parameters, or a value retrieved from a property path. It would be nice to have a system for translated strings with parameters. My use case is that for some breadcrumb I would like to prepend something to a property, and/or surround a property with quotes (e.g. instead of rendering the dynamic value prop as prop, I would like Property : “prop”).

This PR implements this use case by allowing the property path given as label to resolve to a TranslatableMessage instead of a plain string. It respects the translationDomain setting except that false is not considered differently than null so that the default domain is used (indeed it would make no sense to disable translation on a TranslatableMessage).

This allows setting up a breadcrumb like so:

```php
// The breadcrumb uses the breadcrumbLabel property of a Tier object.
const array TIER_BREADCRUMB = [
    'label' => '$tier.breadcrumbLabel',
    'route' => 'app_tier_detail',
    'params' => ['id' => '$tier.id'],
    'translationDomain' => null,
];

// The breadcrumbLabel property returns a TranslatableMessage instead of a plain string.
class Tier {
  public function getBreadcrumbLabel(): TranslatableMessage {
    return new TranslatableMessage('trans_str_with_params', ['%param%' => $this->anotherProperty]);
  }
}

// The Route is not relevant here.
#[Route('/tiers/{id}', name: 'app_tier_detail')]
#[Breadcrumb(TIER_BREADCRUMB)]
public function myRoute(int $id) { /* … */ }
```

Let me know what you think!