### PR TITLE
✨ feat: add Symfony 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,18 +19,18 @@
         }
     ],
     "require": {
-        "php": ">=8.1.0",
-        "symfony/framework-bundle": "~6.4|~7.0",
-        "symfony/property-access": "~6.4|~7.0",
-        "symfony/translation": "~6.4|~7.0",
-        "symfony/yaml": "~6.4|~7.0",
-        "twig/twig": "^2.10|^3.0"
+        "php": ">=8.2.0",
+        "symfony/framework-bundle": "~6.4|~7.0|~8.0",
+        "symfony/property-access": "~6.4|~7.0|~8.0",
+        "symfony/translation": "~6.4|~7.0|~8.0",
+        "symfony/yaml": "~6.4|~7.0|~8.0",
+        "twig/twig": "^3.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3",
-        "phpunit/php-code-coverage": "10.1.16",
-        "phpunit/phpunit": "10.5.30",
-        "symfony/dependency-injection": "~6.4|~7.0",
+        "phpunit/php-code-coverage": "^10.1|^11.0",
+        "phpunit/phpunit": "^10.5|^11.0",
+        "symfony/dependency-injection": "~6.4|~7.0|~8.0",
         "symfony/monolog-bundle": "^3.7"
     },
     "autoload": {


### PR DESCRIPTION
- Update composer.json to support symfony/* ~8.0 packages
- Bump minimum PHP version to 8.2.0
- Update PHPUnit to support ^10.5|^11.0
- Remove Twig 2.x support (Symfony 8 requires Twig 3)

All tests pass with Symfony 8.0.1 and PHPUnit 11.5